### PR TITLE
[Feat] Implement function call structure for runpod serverless

### DIFF
--- a/backend/services/chat_logic.py
+++ b/backend/services/chat_logic.py
@@ -9,10 +9,12 @@ from dotenv import load_dotenv
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_groq import ChatGroq
-from langchain_ollama import ChatOllama
+from langchain_ollama import ChatOllama # runpod 적용 시 제거 예정
 from langchain_openai import ChatOpenAI
 
 from langchain_huggingface import HuggingFaceEmbeddings
+
+from .chat_ollama import call_runpod_ollama 
 
 load_dotenv()
 
@@ -43,6 +45,8 @@ DB_CONFIG = {
 # -----------------------------
 # 모델 설정
 # -----------------------------
+
+# Ollama = runpod 적용 시 제거 예정
 local_llm = ChatOllama(
     model="exaone3.5:7.8b",
     base_url="http://localhost:11434",
@@ -695,6 +699,72 @@ def build_local_draft(user_message: str, user_profile: tuple, selected_model: st
 
     return clean_text(remove_forbidden_headers(result))
 
+# 4/21 runpod serverless 대응 수정
+def build_draft_with_ollama(user_message: str, user_profile: tuple, selected_model: str = "GPT-4o-mini") -> str:
+    profile = parse_user_profile(user_profile)
+    parsed = parse_user_request(user_message, selected_model)
+    sample_context = get_sample_context(selected_model, profile) #profile 정보 기반 sample 검색
+
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", get_local_system_prompt(parsed["question_type"])),
+        ("human", """
+[지원자 정보]
+- 성별: {gender}
+- 학교: {school}
+- 전공: {major}
+- 직무 관련 경험: {exp}
+- 수상 및 대외활동: {awards}
+- 기술 스택 / 자격증: {tech}
+
+[사용자 요청 원문]
+{user_message}
+
+[실제 지원 정보]
+- 실제 지원 회사명: {company}
+- 실제 지원 직무명: {job}
+- 문항: {question}
+- 문항 유형: {question_type}
+- 글자 수 제한: {char_limit}
+
+[유사 샘플 패턴 요약]
+{sample_summary}
+
+[샘플 기반 작성 규칙]
+{style_rules}
+
+[유사 샘플 원문 발췌]
+{sample_excerpt}
+
+요구사항:
+- 샘플은 표현 패턴과 강점 서술 방식을 참고하는 용도로만 활용하라.
+- 실제 회사명과 직무명은 사용자 입력 기준으로만 반영하라.
+- 샘플 문장을 베끼지 말고, 사용자 이력으로 새롭게 써라.
+- 사용자를 단순히 분석 툴을 쓴 사람처럼 쓰지 말고, 데이터를 구조화하고 기준을 정리해 활용 가능한 형태로 연결한 사람처럼 보이게 하라.
+- 자기소개서 본문 초안만 써라.
+        """)
+    ])
+
+    final_prompt = prompt.invoke({
+        "gender": profile["gender"],
+        "school": profile["school"],
+        "major": profile["major"],
+        "exp": profile["exp"],
+        "awards": profile["awards"],
+        "tech": profile["tech"],
+        "user_message": parsed["raw"],
+        "company": parsed["company"] or "미기재",
+        "job": parsed["job"] or "미기재",
+        "question": parsed["question"] or "미기재",
+        "question_type": parsed["question_type"],
+        "char_limit": parsed["char_limit"] or "미기재",
+        "sample_summary": sample_context["sample_summary"],
+        "style_rules": sample_context["style_rules"],
+        "sample_excerpt": sample_context["sample_excerpt"] or "없음",
+    })
+    
+    
+    result = call_runpod_ollama(final_prompt.to_messages()) #runpod 호출로 생성된 답변 받아옴
+    return clean_text(remove_forbidden_headers(result))
 
 def regenerate_local_draft_if_needed(
     user_message: str,
@@ -707,7 +777,7 @@ def regenerate_local_draft_if_needed(
     working_message = user_message
 
     for attempt in range(max_attempts):
-        draft = build_local_draft(working_message, user_profile, selected_model)
+        draft = build_local_draft(working_message, user_profile, selected_model) #build_draft_with_ollama(working_message, user_profile, selected_model)
         is_ok, reason = score_local_draft(draft, parsed)
         last_text = draft
 

--- a/backend/services/chat_ollama.py
+++ b/backend/services/chat_ollama.py
@@ -1,0 +1,31 @@
+import os
+import asyncio
+from langchain_core.messages import BaseMessage
+
+from .exaone_infer import exaone_infer
+
+def call_runpod_ollama(messages: list[BaseMessage]) -> str:
+    """
+    Runpod Serverless를 호출하여 Ollama(EXAONE) 추론 결과를 가져옵니다.
+    """
+    try:
+        result = asyncio.run(exaone_infer(messages))
+        
+        if result.get("ok"):
+            return result["text"]
+        else:
+            raise Exception("생성이 제대로 되지 않았습니다.")
+    except Exception as e:
+        return f"Error: Failed to call Runpod Serverless - {str(e)}"
+    
+if __name__ == "__main__":
+    from langchain_core.prompts import ChatPromptTemplate
+    prompt = ChatPromptTemplate.from_messages(
+        [("system", "당신은 아주 친절한 챗봇입니다. 질문에 잘 답변해주세요"),
+        ("human", "{topic}에 대해 자세하게 설명해 주세요.")]
+    )
+    final_prompt = prompt.invoke({"topic":"LangGraph"})
+    input_messages = [{"role": "user" if m.type == "human" else m.type, "content": m.content} for m in final_prompt.to_messages()]
+    
+    
+    

--- a/backend/services/exaone_infer.py
+++ b/backend/services/exaone_infer.py
@@ -1,0 +1,83 @@
+# from runpod_flash import Endpoint
+# from common.runpod import (
+#     RUNPOD_DATACENTER,
+#     RUNPOD_GPU,
+#     get_runpod_volume,
+# )
+
+
+# @Endpoint(
+#     name="exaone-infer-prod",
+#     gpu=RUNPOD_GPU,
+#     datacenter=RUNPOD_DATACENTER,
+#     volume=get_runpod_volume(),
+#     dependencies=["torch", "transformers>=4.43"],
+# )
+async def exaone_infer(data: dict):
+    import os
+    import torch
+    from transformers import AutoTokenizer, AutoModelForCausalLM
+
+    try:
+        model_path = "/runpod-volume/exaone-3.5-7.8b"
+
+        if not os.path.exists(model_path):
+            return {"ok": False, "error": "model path not found"}
+
+        global_state = globals()
+        tokenizer = global_state.get("_tokenizer")
+        model = global_state.get("_model")
+
+        if tokenizer is None:
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_path,
+                trust_remote_code=True,
+                local_files_only=True,
+            )
+            if tokenizer.pad_token_id is None:
+                tokenizer.pad_token_id = tokenizer.eos_token_id
+            global_state["_tokenizer"] = tokenizer
+
+        if model is None:
+            model = AutoModelForCausalLM.from_pretrained(
+                model_path,
+                torch_dtype=torch.float16,
+                trust_remote_code=True,
+                local_files_only=True,
+            ).to("cuda")
+            model.eval()
+            global_state["_model"] = model
+
+        messages = data["input"]["messages"]
+        full_prompt = tokenizer.apply_chat_template(
+            messages,
+            tokenize = False
+        )
+        max_new_tokens = 8192
+        temperature = float(data["input"]["temperature"])
+        do_sample = temperature > 0.0
+
+        inputs = tokenizer(full_prompt, return_tensors="pt").to("cuda")
+
+        generate_kwargs = {
+            **inputs,
+            "max_new_tokens": max_new_tokens,
+            "do_sample": do_sample,
+            "pad_token_id": tokenizer.pad_token_id,
+            "eos_token_id": tokenizer.eos_token_id
+        }
+
+        if do_sample:
+            generate_kwargs["temperature"] = temperature
+
+        with torch.no_grad():
+            output = model.generate(**generate_kwargs)
+
+        prompt_length = inputs["input_ids"].shape[1]
+        generated_tokens = output[0][prompt_length:]
+        text = tokenizer.decode(generated_tokens, skip_special_tokens=True)
+
+        return {"ok": True, "text": text}
+
+    except Exception as e:
+        return {"ok": False, "error": str(e)}


### PR DESCRIPTION
# [Feat] Implement function call structure for runpod serverless
---

## 📌 요약 (Summary)
Runpod serverless 요청을 위한 함수 호출 구조 설정

---

## ✅ 작업 내용 (To-do List)
상세한 작업 항목을 체크리스트로 관리합니다.
- [x] chat_logic.py: 완성한 프롬포트로 생성 요청을 보내는 call_runpod_ollama 추가 (4/21 검색하면 쉽게 찾을 수 있음)
이후 regenerate_local_draft_if_needed에서 build_local_draft를 대체
- [x] chat_ollama.py: runpod serverless를 비동기로 호출하고 결과를 받아 반환하는 call_runpod_ollama 구현
- [x] exaone_infer.py: runpod에서 실행되는 생성 함수
---

## ⚠️ 주의 사항 (Caution)
신경 써서 확인해야 하거나, 머지 전 주의할 점을 적습니다.
- 구조만 잡아놓은 것이므로 아직 실제로 테스트를 해 볼수는 없습니다. 

---
